### PR TITLE
Push notifications and crash fix

### DIFF
--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -412,9 +412,16 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
 
 - (void)logUrbanAirshipEvent:(MPEvent *)event {
     UACustomEvent *customEvent = [UACustomEvent eventWithName:event.name];
+    Class NSNumberClass = [NSNumber class];
 
-    for (NSString* key in event.info) {
-        [customEvent setValue:event.info[key] forKey:key];
+    for (NSString *key in event.info) {
+        id value = event.info[key];
+
+        if ([value isKindOfClass:NSNumberClass]) {
+            [customEvent setNumberProperty:value forKey:key];
+        } else {
+            [customEvent setStringProperty:[self stringRepresentation:value] forKey:key];
+        }
     }
 
     [[UAirship shared].analytics addEvent:customEvent];

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -165,8 +165,6 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         }
 
         [UAirship takeOff:config];
-        [UAirship push].userPushNotificationsEnabled = YES;
-
         [[UAirship push] updateRegistration];
 
         NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
@@ -676,6 +674,8 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
 }
 
 - (MPKitExecStatus *)setDeviceToken:(NSData *)deviceToken {
+    [UAirship push].userPushNotificationsEnabled = YES;
+
     [UAAppIntegration application:[UIApplication sharedApplication] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 
     return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitUrbanAirship kitCode]
@@ -699,7 +699,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
 
 - (nonnull MPKitExecStatus *)userNotificationCenter:(nonnull UNUserNotificationCenter *)center didReceiveNotificationResponse:(nonnull UNNotificationResponse *)response {
     [UAAppIntegration userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:^{}];
-    
+
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[MPKitUrbanAirship kitCode] returnCode:MPKitReturnCodeSuccess];
     return execStatus;
 }


### PR DESCRIPTION
This PR addresses 2 issues with the UA kit implementation:

1. Wait to enable push after receiving a device token
2. Fix the crash in `logUrbanAirshipEvent`
