### PR TITLE
Prevent automatic request for push authorization

### DIFF
--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -167,6 +167,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
             config.inProduction = YES;
         }
 
+        [UAirship push].userPushNotificationsEnabledByDefault = NO;
         [UAirship takeOff:config];
         [[UAirship push] updateRegistration];
 


### PR DESCRIPTION
When first installing an app, Urban Airship immediately prompts for push authorization. Adding `[UAirship push].userPushNotificationsEnabledByDefault = NO;` prevents this from happening. We're open to other suggestions, but this seems to be what we need to happen.