### PR TITLE
Updated Urban Airship SDK to latest version

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,5 @@
 use_frameworks!
+platform :ios, '9.0'
 
 target 'mParticle-UrbanAirship_Example' do
   pod 'mParticle-UrbanAirship', :path => '../'

--- a/Example/mParticle-UrbanAirship.xcodeproj/project.pbxproj
+++ b/Example/mParticle-UrbanAirship.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
-		FDD5A637446E06F07A47D6C2 /* Pods_mParticle_UrbanAirship_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BBC70A8CA602A38F1C3F4B1 /* Pods_mParticle_UrbanAirship_Example.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,8 +33,6 @@
 
 /* Begin PBXFileReference section */
 		1BB3365D0EEED8692DBF8D5C /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		2BBC70A8CA602A38F1C3F4B1 /* Pods_mParticle_UrbanAirship_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_mParticle_UrbanAirship_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		54792E27B337676695D8E6F1 /* Pods-mParticle-UrbanAirship_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-UrbanAirship_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-mParticle-UrbanAirship_Example/Pods-mParticle-UrbanAirship_Example.release.xcconfig"; sourceTree = "<group>"; };
 		56F2F552649DFF90A34E821E /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* mParticle-UrbanAirship_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "mParticle-UrbanAirship_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -54,8 +51,6 @@
 		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		9AF9C98E1257B4C530E9A277 /* mParticle-UrbanAirship.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "mParticle-UrbanAirship.podspec"; path = "../mParticle-UrbanAirship.podspec"; sourceTree = "<group>"; };
-		C846634C8D1636A7C62229DE /* Pods-mParticle-UrbanAirship_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-UrbanAirship_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-mParticle-UrbanAirship_Example/Pods-mParticle-UrbanAirship_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		FD6E14290F7D7887D2B8705A /* Pods_mParticle_UrbanAirship_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_mParticle_UrbanAirship_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,7 +61,6 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				FDD5A637446E06F07A47D6C2 /* Pods_mParticle_UrbanAirship_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,7 +84,6 @@
 				6003F593195388D20070C39A /* Example for mParticle-UrbanAirship */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
-				C1223B63F4F5C11BFB18115A /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -110,8 +103,6 @@
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
-				2BBC70A8CA602A38F1C3F4B1 /* Pods_mParticle_UrbanAirship_Example.framework */,
-				FD6E14290F7D7887D2B8705A /* Pods_mParticle_UrbanAirship_Tests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -152,15 +143,6 @@
 			name = "Podspec Metadata";
 			sourceTree = "<group>";
 		};
-		C1223B63F4F5C11BFB18115A /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				C846634C8D1636A7C62229DE /* Pods-mParticle-UrbanAirship_Example.debug.xcconfig */,
-				54792E27B337676695D8E6F1 /* Pods-mParticle-UrbanAirship_Example.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -168,15 +150,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "mParticle-UrbanAirship_Example" */;
 			buildPhases = (
-				B5A99EED5011A35D8A1E3E30 /* 📦 Check Pods Manifest.lock */,
-				CAD100F95C8D576BB8468015 /* [CP] Check Pods Manifest.lock */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				8CD012351A757E6822178622 /* [CP] Embed Pods Frameworks */,
-				16A5829EE57203A8728DECF6 /* [CP] Copy Pods Resources */,
-				B4AFCB25D0032565BE8257E0 /* 📦 Embed Pods Frameworks */,
-				C64AC85E2F27EE18458B8AD5 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -212,7 +188,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = MP;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = "Urban Airship";
 				TargetAttributes = {
 					6003F589195388D20070C39A = {
@@ -268,99 +244,6 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		16A5829EE57203A8728DECF6 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-mParticle-UrbanAirship_Example/Pods-mParticle-UrbanAirship_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8CD012351A757E6822178622 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-mParticle-UrbanAirship_Example/Pods-mParticle-UrbanAirship_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B4AFCB25D0032565BE8257E0 /* 📦 Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "📦 Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-mParticle-UrbanAirship_Example/Pods-mParticle-UrbanAirship_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B5A99EED5011A35D8A1E3E30 /* 📦 Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "📦 Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		C64AC85E2F27EE18458B8AD5 /* 📦 Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "📦 Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-mParticle-UrbanAirship_Example/Pods-mParticle-UrbanAirship_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		CAD100F95C8D576BB8468015 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
 		6003F586195388D20070C39A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -409,19 +292,32 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -449,18 +345,31 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -476,13 +385,13 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C846634C8D1636A7C62229DE /* Pods-mParticle-UrbanAirship_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "mParticle-UrbanAirship/mParticle-UrbanAirship-Prefix.pch";
 				INFOPLIST_FILE = "mParticle-UrbanAirship/mParticle-UrbanAirship-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.urbanairship.richpush;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -492,13 +401,13 @@
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 54792E27B337676695D8E6F1 /* Pods-mParticle-UrbanAirship_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "mParticle-UrbanAirship/mParticle-UrbanAirship-Prefix.pch";
 				INFOPLIST_FILE = "mParticle-UrbanAirship/mParticle-UrbanAirship-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.urbanairship.richpush;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/mParticle-UrbanAirship.xcodeproj/xcshareddata/xcschemes/mParticle-UrbanAirship-Example.xcscheme
+++ b/Example/mParticle-UrbanAirship.xcodeproj/xcshareddata/xcschemes/mParticle-UrbanAirship-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/mParticle-UrbanAirship/MPAppDelegate.m
+++ b/Example/mParticle-UrbanAirship/MPAppDelegate.m
@@ -28,9 +28,8 @@ NSString* const appSecret = @"app_secret";
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    [[MParticle sharedInstance] startWithKey:appKey
-                                      secret:appSecret];
-
+    MParticleOptions *options = [MParticleOptions optionsWithKey:appKey secret:appSecret];
+    [[MParticle sharedInstance] startWithOptions: options];
 
     // Override point for customization after application launch.
     return YES;

--- a/mParticle-UrbanAirship.podspec
+++ b/mParticle-UrbanAirship.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-UrbanAirship"
-    s.version          = "7.3.11"
+    s.version          = "7.3.12"
     s.summary          = "Urban Airship integration for mParticle"
 
     s.description      = <<-DESC
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-urbanairship.git", :tag => s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticles"
 
-    s.ios.deployment_target = "8.0"
+    s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-UrbanAirship/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.3.0'
-    s.ios.dependency 'UrbanAirship-iOS-SDK', '~> 8.5'
+    s.ios.dependency 'UrbanAirship-iOS-SDK', '~> 9.0'
 end

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -152,7 +152,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
     static dispatch_once_t kitPredicate;
 
     dispatch_once(&kitPredicate, ^{
-        _started = YES;
+        self->_started = YES;
 
         UAConfig *config = [UAConfig defaultConfig];
         config.automaticSetupEnabled = NO;
@@ -787,7 +787,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
 - (MPKitExecStatus *)handleActionWithIdentifier:(NSString *)identifier
                           forRemoteNotification:(NSDictionary *)userInfo
                                withResponseInfo:(NSDictionary *)responseInfo
-                              completionHandler:(void (^)())completionHandler {
+                              completionHandler:(void (^)(void))completionHandler {
 
     [UAAppIntegration application:[UIApplication sharedApplication]
        handleActionWithIdentifier:identifier
@@ -813,20 +813,18 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
-#if TARGET_OS_IOS == 1 && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
-- (nonnull MPKitExecStatus *)userNotificationCenter:(nonnull UNUserNotificationCenter *)center willPresentNotification:(nonnull UNNotification *)notification {
+- (nonnull MPKitExecStatus *)userNotificationCenter:(nonnull UNUserNotificationCenter *)center willPresentNotification:(nonnull UNNotification *)notification  API_AVAILABLE(ios(10.0)){
     [UAAppIntegration userNotificationCenter:center willPresentNotification:notification withCompletionHandler:^(UNNotificationPresentationOptions options) {}];
 
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[MPKitUrbanAirship kitCode] returnCode:MPKitReturnCodeSuccess];
     return execStatus;
 }
 
-- (nonnull MPKitExecStatus *)userNotificationCenter:(nonnull UNUserNotificationCenter *)center didReceiveNotificationResponse:(nonnull UNNotificationResponse *)response {
+- (nonnull MPKitExecStatus *)userNotificationCenter:(nonnull UNUserNotificationCenter *)center didReceiveNotificationResponse:(nonnull UNNotificationResponse *)response  API_AVAILABLE(ios(10.0)){
     [UAAppIntegration userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:^{}];
 
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[MPKitUrbanAirship kitCode] returnCode:MPKitReturnCodeSuccess];
     return execStatus;
 }
-#endif
 
 @end


### PR DESCRIPTION
This PR adds the support to the latest SDK for Urban Airship

To work Urban Airship dropped the support to iOS 8 and therefore the pod spec had to change the minimum deployment target.

Used new availability annotations to mark iOS10 and up methods available for the compiler.