### PR TITLE
Update urban airship

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode9.3
+osx_image: xcode10.1
 language: objective-c
 script:
 - sudo gem install cocoapods -v 1.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 osx_image: xcode10.1
 language: objective-c
 script:
-- sudo gem install cocoapods -v 1.5.0
+- sudo gem install cocoapods -v 1.5.3
 - travis_retry pod repo update > /dev/null
 - pod lib lint --use-libraries --allow-warnings || pod lib lint --allow-warnings

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ A kit takes care of initializing and forwarding information depending on what yo
 Please refer to installation instructions in the core mParticle Apple SDK [README](https://github.com/mParticle/mparticle-apple-sdk#get-the-sdk), or check out our [SDK Documentation](http://docs.mparticle.com/#mobile-sdk-guide) site to learn more.
 
 
+## Push Registration
+
+Push registration is not handled by the Urban Airship SDK when the passive registration setting is enabled. This prevents out-of-the-box categories from being registered automatically. 
+
+Registering out-of-the-box categories manually can be accomplished by accessing the defaultCategories class method on MPKitUrbanAirship and setting them on the UNNotificationCenter:
+
+```swift
+    UNUserNotificationCenter.current().requestAuthorization(options: [UNAuthorizationOptions.alert]) { (success, err) in
+        UNUserNotificationCenter.current().setNotificationCategories(MPKitUrbanAirship.defaultCategories())
+    }
+```
+
 ## Support
 
 Questions? Give us a shout at <support@mparticle.com>

--- a/mParticle-UrbanAirship.podspec
+++ b/mParticle-UrbanAirship.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-UrbanAirship"
-    s.version          = "7.8.5"
+    s.version          = "7.9.0"
     s.summary          = "Urban Airship integration for mParticle"
 
     s.description      = <<-DESC
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-urbanairship.git", :tag => s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticles"
 
-    s.ios.deployment_target = "9.0"
+    s.ios.deployment_target = "10.0"
     s.ios.source_files      = 'mParticle-UrbanAirship/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.8.0'
-    s.ios.dependency 'UrbanAirship-iOS-SDK', '~> 9.0'
+    s.ios.dependency 'UrbanAirship-iOS-SDK', '~> 10.1'
 end

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.h
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.h
@@ -29,4 +29,12 @@
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
 
+/**
+* Default out-of-the-box categories.
+*
+* @note These notification categories need to be set on the current notification center to retain
+* out-of-the-box categories functionality.
+*/
++ (NSSet<UNNotificationCategory *> *)defaultCategories;
+
 @end

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -774,40 +774,8 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
-- (MPKitExecStatus *)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo {
-    [UAAppIntegration application:[UIApplication sharedApplication]
-       handleActionWithIdentifier:identifier
-            forRemoteNotification:userInfo
-                completionHandler:^{}];
-
-    return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitUrbanAirship kitCode]
-                                         returnCode:MPKitReturnCodeSuccess];
-}
-
-- (MPKitExecStatus *)handleActionWithIdentifier:(NSString *)identifier
-                          forRemoteNotification:(NSDictionary *)userInfo
-                               withResponseInfo:(NSDictionary *)responseInfo
-                              completionHandler:(void (^)(void))completionHandler {
-
-    [UAAppIntegration application:[UIApplication sharedApplication]
-       handleActionWithIdentifier:identifier
-            forRemoteNotification:userInfo
-                 withResponseInfo:responseInfo
-                completionHandler:completionHandler];
-
-    return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitUrbanAirship kitCode]
-                                         returnCode:MPKitReturnCodeSuccess];
-}
-
 - (MPKitExecStatus *)setDeviceToken:(NSData *)deviceToken {
     [UAAppIntegration application:[UIApplication sharedApplication] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-
-    return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitUrbanAirship kitCode]
-                                         returnCode:MPKitReturnCodeSuccess];
-}
-
-- (MPKitExecStatus *)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)settings {
-    [UAAppIntegration application:[UIApplication sharedApplication] didRegisterUserNotificationSettings:settings];
 
     return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitUrbanAirship kitCode]
                                          returnCode:MPKitReturnCodeSuccess];

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -199,8 +199,14 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
 
     // Configure event tags mapping
 
-    NSString *tagMappingStr = [configuration[kMPUAEventTagKey] stringByRemovingPercentEncoding];
-    NSData *tagMappingData = [tagMappingStr dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *tagMappingStr;
+    NSData *tagMappingData;
+
+    if (configuration[kMPUAEventTagKey] != nil && configuration[kMPUAEventTagKey] != [NSNull null]) {
+        tagMappingStr = [configuration[kMPUAEventAttributeTagKey] stringByRemovingPercentEncoding];
+        tagMappingData = [tagMappingStr dataUsingEncoding:NSUTF8StringEncoding];
+    }
+
     NSError *error = nil;
     NSArray<NSDictionary<NSString *, NSString *> *> *tagMappingConfig = nil;
 
@@ -214,8 +220,10 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
     }
 
     // Configure event attribute tags mapping
-    tagMappingStr = [configuration[kMPUAEventAttributeTagKey] stringByRemovingPercentEncoding];
-    tagMappingData = [tagMappingStr dataUsingEncoding:NSUTF8StringEncoding];
+    if (configuration[kMPUAEventAttributeTagKey] != nil && configuration[kMPUAEventAttributeTagKey] != [NSNull null]) {
+        tagMappingStr = [configuration[kMPUAEventAttributeTagKey] stringByRemovingPercentEncoding];
+        tagMappingData = [tagMappingStr dataUsingEncoding:NSUTF8StringEncoding];
+    }
     error = nil;
     tagMappingConfig = nil;
 

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -157,6 +157,9 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         UAConfig *config = [UAConfig defaultConfig];
         config.automaticSetupEnabled = NO;
 
+        // Enable passive APNS registration
+        config.requestAuthorizationToUseNotifications = NO;
+
         if ([MParticle sharedInstance].environment == MPEnvironmentDevelopment) {
             config.developmentAppKey = self.configuration[UAConfigAppKey];
             config.developmentAppSecret = self.configuration[UAConfigAppSecret];
@@ -168,6 +171,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         }
 
         [UAirship takeOff:config];
+        UAirship.push.userPushNotificationsEnabledByDefault = YES;
         [[UAirship push] updateRegistration];
 
         NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -128,7 +128,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
 }
 
 + (NSSet *)defaultCategories {
-    return [UANotificationCategories createCategoriesFromFile: [[UAirship resources] pathForResource:@"UANotificationCategories" ofType:@"plist"]];
+    return [UANotificationCategories createCategoriesFromFile:[[UAirship resources] pathForResource:@"UANotificationCategories" ofType:@"plist"]];
 }
 
 #pragma mark - MPKitInstanceProtocol methods
@@ -210,7 +210,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
     NSString *tagMappingStr;
     NSData *tagMappingData;
 
-    if (configuration[kMPUAEventTagKey] != nil && configuration[kMPUAEventTagKey] != [NSNull null]) {
+    if (configuration && configuration[kMPUAEventTagKey] != [NSNull null]) {
         tagMappingStr = [configuration[kMPUAEventAttributeTagKey] stringByRemovingPercentEncoding];
         tagMappingData = [tagMappingStr dataUsingEncoding:NSUTF8StringEncoding];
     }
@@ -228,7 +228,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
     }
 
     // Configure event attribute tags mapping
-    if (configuration[kMPUAEventAttributeTagKey] != nil && configuration[kMPUAEventAttributeTagKey] != [NSNull null]) {
+    if (configuration && configuration[kMPUAEventAttributeTagKey] != [NSNull null]) {
         tagMappingStr = [configuration[kMPUAEventAttributeTagKey] stringByRemovingPercentEncoding];
         tagMappingData = [tagMappingStr dataUsingEncoding:NSUTF8StringEncoding];
     }

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -127,6 +127,10 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
     [MParticle registerExtension:kitRegister];
 }
 
++ (NSSet *)defaultCategories {
+    return [UANotificationCategories createCategoriesFromFile: [[UAirship resources] pathForResource:@"UANotificationCategories" ofType:@"plist"]];
+}
+
 #pragma mark - MPKitInstanceProtocol methods
 
 #pragma mark Kit instance and lifecycle


### PR DESCRIPTION
**What this PR does:**
1. Updates the plugin to use Urban Airship SDK ~>10.1.
2. Adds passive registration functionality. 
3. Adds public access to the set of categories registered by default by the Urban Airship SDK.

**Background:**
The plugin now exclusively supports iOS 10+ which necessitates the removal of a couple push-related UIApplication callbacks. The podspec also reflects these changes to minimum deployment target. 

Passive registration allows the plugin to work nicely in parallel with pre-existing or alternative push schemes. This removes the need to enable push or make any Urban Airship specific calls when integrating the SDK (with the exception of a default categories registration, if required). This comes with a relatively minor drawback of preventing default category registration by the Urban Airship SDK. The means to work around this issue have also been added with a short explanation included in the readme.

**Testing:**
Manually tested end to end on iOS 12 and iOS 10