### PR TITLE
[airship-sdk-11.0.0] update to airship SDK 11.0.0

### DIFF
--- a/mParticle-UrbanAirship.podspec
+++ b/mParticle-UrbanAirship.podspec
@@ -16,5 +16,6 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "10.0"
     s.ios.source_files      = 'mParticle-UrbanAirship/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.10.0'
-    s.ios.dependency 'UrbanAirship-iOS-SDK', '~> 10.1'
+    s.ios.dependency 'UrbanAirship-iOS-SDK', '~> 11.0'
 end
+


### PR DESCRIPTION
Hi there,

The airship SDK has gotten a bit out of date. This brings the integration to SDK 11.0.0. I'd appreciate some help testing this, as we don't have a shared account on mParticle. Should be fairly straightforward, though.