### PR TITLE
Airship SDK from 15.0 to 16.7

### DIFF
--- a/Example/mParticle-UrbanAirship/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/mParticle-UrbanAirship/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,52 +2,97 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Example/mParticle-UrbanAirship/Main.storyboard
+++ b/Example/mParticle-UrbanAirship/Main.storyboard
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="whP-gf-Uak">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="whP-gf-Uak">
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,9 +15,9 @@
                         <viewControllerLayoutGuide type="bottom" id="Mvr-aV-6Um"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="TpU-gO-2f1">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tc2-Qw-aMS" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Airship",
+        "repositoryURL": "https://github.com/urbanairship/ios-library",
+        "state": {
+          "branch": null,
+          "revision": "cf31f8c232ede66546e2a68f53fc97e684daeb8a",
+          "version": "16.7.0"
+        }
+      },
+      {
+        "package": "mParticle-Apple-SDK",
+        "repositoryURL": "https://github.com/mParticle/mparticle-apple-sdk",
+        "state": {
+          "branch": null,
+          "revision": "af03e78435e3cbc2cfdcd09256a613d85adb205b",
+          "version": "8.8.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "Airship",
                url: "https://github.com/urbanairship/ios-library",
-               .upToNextMajor(from: "15.0.0")),
+               .upToNextMajor(from: "16.7.0")),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## UrbanAirship Kit Integration
 
-This repository contains the [UrbanAirship](https://www.urbanairship.com) integration for the [mParticle Apple SDK](https://github.com/mParticle/mparticle-apple-sdk).
+This repository contains the [Airship](https://www.airship.com) integration for the [mParticle Apple SDK](https://github.com/mParticle/mparticle-apple-sdk).
 
 ### Adding the integration
 
@@ -18,7 +18,7 @@ This repository contains the [UrbanAirship](https://www.urbanairship.com) integr
 
 ## Push Registration
 
-Push registration is not handled by the Urban Airship SDK when the passive registration setting is enabled. This prevents out-of-the-box categories from being registered automatically. 
+Push registration is not handled by the Airship SDK when the passive registration setting is enabled. This prevents out-of-the-box categories from being registered automatically. 
 
 Registering out-of-the-box categories manually can be accomplished by accessing the defaultCategories class method on MPKitUrbanAirship and setting them on the UNNotificationCenter:
 
@@ -30,7 +30,7 @@ Registering out-of-the-box categories manually can be accomplished by accessing 
 
 ### Documentation
 
-[UrbanAirship integration](https://docs.mparticle.com/integrations/urbanairship/event/)
+[Airship integration](https://docs.mparticle.com/integrations/airship/event/)
 
 ### License
 

--- a/mParticle-UrbanAirship.podspec
+++ b/mParticle-UrbanAirship.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-UrbanAirship"
     s.version          = "8.0.2"
-    s.summary          = "Urban Airship integration for mParticle"
+    s.summary          = "Airship integration for mParticle"
 
     s.description      = <<-DESC
-                       This is the Urban Airship integration for mParticle.
+                       This is the Airship integration for mParticle.
                        DESC
 
     s.homepage         = "https://www.mparticle.com"
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-UrbanAirship/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'Airship', '~> 15.0'
+    s.ios.dependency 'AirshipKit', '~> 16.7'
 end
 

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -5,7 +5,7 @@
     #if __has_include("AirshipLib.h")
         #import "AirshipLib.h"
     #else
-        @import Airship;
+        @import AirshipKit;
     #endif
 #endif
 


### PR DESCRIPTION
# Summary

Requesting Airship SDK upgrade from SDK 15 to 16.7.
Removed Urban Airship from documentation where appropriate and fixed broken link
Updated podspec to reflect the latest SDK version 16.7 and name change from Airship to ['AirshipKit'](https://github.com/urbanairship/ios-library/blob/main/Documentation/Migration/migration-guide-15-16.md)

