### PR TITLE
Fix use of deprecated method in remove attribute

### DIFF
--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -394,7 +394,10 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         }
         
         if (uaTag) {
-            [[UAirship channel] removeTag:uaTag];
+            [[UAirship channel] editTags:^(UATagEditor * _Nonnull editor) {
+                [editor removeTag:key];
+                [editor apply];
+            }];
             [[UAirship channel] updateRegistration];
             
             returnCode = MPKitReturnCodeSuccess;


### PR DESCRIPTION
## Summary
- Switch to using new method for removing tags from Airship

## Testing Plan
- Validated this matches the existing behavior of Airship's open source SDK when calling existing method.

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-8187
