### PR TITLE
docs: document airship removeTag functionality

### DIFF
--- a/Example/mParticle-UrbanAirship/MPAppDelegate.m
+++ b/Example/mParticle-UrbanAirship/MPAppDelegate.m
@@ -18,7 +18,6 @@
 
 #import "MPAppDelegate.h"
 #import "mParticle.h"
-#import "MPKitUrbanAirship.h"
 
 @implementation MPAppDelegate
 

--- a/Example/mParticle-UrbanAirship/MPViewController.m
+++ b/Example/mParticle-UrbanAirship/MPViewController.m
@@ -17,6 +17,7 @@
 //
 
 #import "MPViewController.h"
+@import AirshipKit;
 
 @interface MPViewController ()
 
@@ -28,6 +29,16 @@
 {
     [super viewDidLoad];
 	// Do any additional setup after loading the view, typically from a nib.
+}
+
+- (void)removeTag:(nonnull NSString *)key {
+    if (key && (NSNull *)key != [NSNull null] && ![key isEqualToString:@""]) {
+        [[UAirship channel] editTags:^(UATagEditor * _Nonnull editor) {
+            [editor removeTag:key];
+            [editor apply];
+        }];
+        [[UAirship channel] updateRegistration];
+    }
 }
 
 - (void)didReceiveMemoryWarning

--- a/README.md
+++ b/README.md
@@ -28,6 +28,36 @@ Registering out-of-the-box categories manually can be accomplished by accessing 
     }
 ```
 
+## Tag-Based Segmentation
+
+All mParticle user attributes are forwarded to Airship as [tags](https://docs.airship.com/platform/ios/segmentation/) which can be used to identify and segment your audience.
+
+Most clients prefer for all tags to remain constant if set. But, a tag can be removed manually by invoking removeTag directly on the Airship SDK as shown bellow.
+
+#### Swift
+```swift
+    private func removeTag(key: String) {
+        if (!key.isEmpty) {
+            Airship.channel.editTags { editor in
+                editor.remove(key)
+            }
+            Airship.channel.updateRegistration()
+        }
+    }
+```
+#### Objective-C
+```objective-c
+    - (void)removeTag:(nonnull NSString *)key {
+        if (key && (NSNull *)key != [NSNull null] && ![key isEqualToString:@""]) {
+            [[UAirship channel] editTags:^(UATagEditor * _Nonnull editor) {
+                [editor removeTag:key];
+                [editor apply];
+            }];
+            [[UAirship channel] updateRegistration];
+        }
+    }
+```
+
 ### Documentation
 
 [Airship integration](https://docs.mparticle.com/integrations/airship/event/)


### PR DESCRIPTION
## Summary
- Add Airship Kit documentation for removing tags by invoking removeTag directly on the Airship SDK.

## Testing Plan
- Tested end to end using Higg's sample app

## Reference Issue
- Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4499
