### PR TITLE
feat: add support for custom domain proxy

### DIFF
--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -25,6 +25,7 @@ NSString * const UAIdentityCustomer = @"customer_id";
 
 NSString * const UAConfigAppKey = @"applicationKey";
 NSString * const UAConfigAppSecret = @"applicationSecret";
+NSString * const UAConfigCustomDomainProxyUrl = @"customDomainProxyUrl";
 NSString * const UAConfigEnableTags = @"enableTags";
 NSString * const UAConfigIncludeUserAttributes = @"includeUserAttributes";
 NSString * const UAConfigNamedUserId = @"namedUserIdField";
@@ -140,6 +141,12 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         
         // Enable passive APNS registration
         config.requestAuthorizationToUseNotifications = NO;
+
+        // Enable custom domain proxy if provided
+        if( self.configuration[UAConfigCustomDomainProxyUrl] ){
+            config.initialConfigURL = self.configuration[UAConfigCustomDomainProxyUrl];
+            config.URLAllowList = @[self.configuration[UAConfigCustomDomainProxyUrl]];
+        }
         
         if ([MParticle sharedInstance].environment == MPEnvironmentDevelopment) {
             config.developmentAppKey = self.configuration[UAConfigAppKey];

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -143,7 +143,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         config.requestAuthorizationToUseNotifications = NO;
 
         // Enable custom domain proxy if provided
-        if( self.configuration[UAConfigCustomDomainProxyUrl] ){
+        if (self.configuration[UAConfigCustomDomainProxyUrl]) {
             config.initialConfigURL = self.configuration[UAConfigCustomDomainProxyUrl];
             config.URLAllowList = @[self.configuration[UAConfigCustomDomainProxyUrl]];
         }

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -145,7 +145,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         // Enable custom domain proxy if provided
         if (self.configuration[UAConfigCustomDomainProxyUrl]) {
             config.initialConfigURL = self.configuration[UAConfigCustomDomainProxyUrl];
-            config.URLAllowList = @[self.configuration[UAConfigCustomDomainProxyUrl]];
+            config.URLAllowList = [config.URLAllowList arrayByAddingObject:self.configuration[UAConfigCustomDomainProxyUrl]];
         }
         
         if ([MParticle sharedInstance].environment == MPEnvironmentDevelopment) {


### PR DESCRIPTION
 ## Summary
 - Read the connection setting "customDomainProxyUrl" and set it 

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested without setting customDomainProxyUrl in mP UI first. The integration worked normally and events were forwarded to Airship.
 - After setting a dummy value "https://analytics.example.com" for customDomainProxyUrl in mP UI, the integration stopped working and I started getting "A server with the specified hostname could not be found." in the Xcode console.
 - Further testing needs to be done with a working custom domain proxy.
