### PR TITLE
feat: Update to Partner Version 18.2 and add Privacy Manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.0.0")),
+               .upToNextMajor(from: "8.22.0")),
       .package(name: "Airship",
                url: "https://github.com/urbanairship/ios-library",
                .upToNextMajor(from: "18.2.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "Airship",
                url: "https://github.com/urbanairship/ios-library",
-               .upToNextMajor(from: "16.7.0")),
+               .upToNextMajor(from: "18.2.0")),
     ],
     targets: [
         .target(
@@ -25,6 +25,7 @@ let package = Package(
                 .product(name: "AirshipCore", package: "Airship"),
             ],
             path: "mParticle-UrbanAirship",
+            resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "mParticle-UrbanAirship",
-    platforms: [ .iOS(.v11) ],
+    platforms: [ .iOS(.v14) ],
     products: [
         .library(
             name: "mParticle-UrbanAirship",

--- a/mParticle-UrbanAirship.podspec
+++ b/mParticle-UrbanAirship.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "14.0"
     s.ios.source_files      = 'mParticle-UrbanAirship/*.{h,m,mm}'
-    s.ios.resource_bundles = { 'mParticle-Localytics-Privacy' => ['mParticle-Localytics/PrivacyInfo.xcprivacy'] }
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+    s.ios.resource_bundles = { 'mParticle-UrbanAirship-Privacy' => ['mParticle-UrbanAirship/PrivacyInfo.xcprivacy'] }
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     s.ios.dependency 'Airship', '~> 18.2'
 end
 

--- a/mParticle-UrbanAirship.podspec
+++ b/mParticle-UrbanAirship.podspec
@@ -15,7 +15,8 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "14.0"
     s.ios.source_files      = 'mParticle-UrbanAirship/*.{h,m,mm}'
+    s.ios.resource_bundles = { 'mParticle-Localytics-Privacy' => ['mParticle-Localytics/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'Airship', '~> 17.7'
+    s.ios.dependency 'Airship', '~> 18.2'
 end
 

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -160,7 +160,6 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         
         [UAirship takeOff:config launchOptions:_launchOptions];
         UAirship.push.userPushNotificationsEnabled = YES;
-        [[UAirship push] updateRegistration];
         
         NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
         
@@ -171,7 +170,7 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         
         [notificationCenter addObserver:self
                                selector:@selector(updateChannelIntegration)
-                                   name:UAChannel.channelCreatedEvent
+                                   name:UAirshipNotificationChannelCreated.name
                                  object:nil];
         
         [self updateChannelIntegration];
@@ -183,7 +182,8 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
 }
 
 - (id const)providerKitInstance {
-    return [self started] ? [UAirship shared] : nil;
+    // Urban Airship no longer provides a shared instance. Instead their API's now all work as class methods on UAirship
+    return nil;
 }
 
 - (void)setConfiguration:(NSDictionary *)configuration {
@@ -351,7 +351,9 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         }
         
         if (uaTag) {
-            [[UAirship channel] addTag:uaTag];
+            [UAirship.channel editTags:^(UATagEditor *editor) {
+                [editor addTag:uaTag];
+            }];
             
             returnCode = MPKitReturnCodeSuccess;
         } else {
@@ -375,7 +377,9 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
         }
         
         if (uaTag) {
-            [[UAirship channel] addTag:uaTag];
+            [UAirship.channel editTags:^(UATagEditor *editor) {
+                [editor addTag:uaTag];
+            }];
             
             returnCode = MPKitReturnCodeSuccess;
         } else {
@@ -432,9 +436,9 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
 
 - (MPKitExecStatus *)setOptOut:(BOOL)optOut {
     if(!optOut) {
-        [UAirship shared].privacyManager.enabledFeatures = UAFeaturesAll;
+        UAirship.privacyManager.enabledFeatures = UAFeaturesAll;
     } else {
-        [UAirship shared].privacyManager.enabledFeatures = UAFeaturesNone;
+        UAirship.privacyManager.enabledFeatures = UAFeaturesNone;
     }
     
     return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitUrbanAirship kitCode]
@@ -672,7 +676,9 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
     
     if (matchTagMappings.count > 0) {
         [matchTagMappings enumerateObjectsUsingBlock:^(MPUATagMapping * _Nonnull tagMapping, NSUInteger idx, BOOL * _Nonnull stop) {
-            [[UAirship channel] addTag:tagMapping.value];
+            [UAirship.channel editTags:^(UATagEditor *editor) {
+                [editor addTag:tagMapping.value];
+            }];
         }];
     }
 }
@@ -690,7 +696,9 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
     
     if (matchTagMappings.count > 0) {
         [matchTagMappings enumerateObjectsUsingBlock:^(MPUATagMapping * _Nonnull tagMapping, NSUInteger idx, BOOL * _Nonnull stop) {
-            [[UAirship channel] addTag:tagMapping.value];
+            [UAirship.channel editTags:^(UATagEditor *editor) {
+                [editor addTag:tagMapping.value];
+            }];
         }];
     }
 }
@@ -725,8 +733,10 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
                 
                 if (attributeString) {
                     NSString *tagPlusAttributeValue = [NSString stringWithFormat:@"%@-%@", tagMapping.value, attributeString];
-                    [[UAirship channel] addTag:tagPlusAttributeValue];
-                    [[UAirship channel] addTag:tagMapping.value];
+                    [UAirship.channel editTags:^(UATagEditor *editor) {
+                        [editor addTag:tagPlusAttributeValue];
+                        [editor addTag:tagMapping.value];
+                    }];
                 }
             }];
         }
@@ -753,8 +763,10 @@ NSString * const kMPUAMapTypeEventAttributeClassDetails = @"EventAttributeClassD
                 
                 if (attributeString) {
                     NSString *tagPlusAttributeValue = [NSString stringWithFormat:@"%@-%@", tagMapping.value, attributeString];
-                    [[UAirship channel] addTag:tagPlusAttributeValue];
-                    [[UAirship channel] addTag:tagMapping.value];
+                    [UAirship.channel editTags:^(UATagEditor *editor) {
+                        [editor addTag:tagPlusAttributeValue];
+                        [editor addTag:tagMapping.value];
+                    }];
                 }
             }];
         }

--- a/mParticle-UrbanAirship/PrivacyInfo.xcprivacy
+++ b/mParticle-UrbanAirship/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
 - Updated to latest version of Urban Airship and added Privacy manifest

 ## Testing Plan
 - Tested on local sample app. Had to wait for a patch to resolve a problem I found https://github.com/urbanairship/ios-library/issues/404 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6397
