### PR TITLE
fix: Mismatch in Minimum iOS Deployment Target Between Airship SDK and mParticle Airship Kit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(
     name: "mParticle-UrbanAirship",
-    platforms: [ .iOS(.v14) ],
+    platforms: [ .iOS(.v15) ],
     products: [
         .library(
             name: "mParticle-UrbanAirship",
@@ -22,7 +22,7 @@ let package = Package(
             name: "mParticle-UrbanAirship",
             dependencies: [
                 .byName(name: "mParticle-Apple-SDK"),
-                .product(name: "AirshipCore", package: "Airship"),
+                .product(name: "AirshipObjectiveC", package: "Airship"),
             ],
             path: "mParticle-UrbanAirship",
             resources: [.process("PrivacyInfo.xcprivacy")],

--- a/mParticle-UrbanAirship/MPKitUrbanAirship.m
+++ b/mParticle-UrbanAirship/MPKitUrbanAirship.m
@@ -1,6 +1,7 @@
 #import "MPKitUrbanAirship.h"
 #if SWIFT_PACKAGE
     @import AirshipCore;
+    @import AirshipObjectiveC;
 #else
     #if __has_include("AirshipLib.h")
         #import "AirshipLib.h"


### PR DESCRIPTION
 ## Summary
- bump-up swift-tools-version to 5.10 to support .v15
- update platform to ios 15
- use objc dependency to Airship "AirshipObjectiveC" our code consume classes which were removed from swift version of Airship
- import obj classes

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-137
