### PR TITLE
Feat: SDKE-284: Mismatch in Minimum iOS Deployment Target Between Airship SDK and mParticle Airship Kit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
 ## Summary
- update swift-tools-version to 6.0

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-284
