### PR TITLE
feat: Upgrade Airship SDK to v20

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "mParticle-UrbanAirship",
-    platforms: [ .iOS(.v15) ],
+    platforms: [ .iOS(.v16) ],
     products: [
         .library(
             name: "mParticle-UrbanAirship",
@@ -12,10 +12,10 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.22.0")),
+               .upToNextMajor(from: "8.41.1")),
       .package(name: "Airship",
                url: "https://github.com/urbanairship/ios-library",
-               .upToNextMajor(from: "19.1.0")),
+               .upToNextMajor(from: "20.0.3")),
     ],
     targets: [
         .target(

--- a/mParticle-UrbanAirship.podspec
+++ b/mParticle-UrbanAirship.podspec
@@ -13,10 +13,10 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-urbanairship.git", :tag => "v" + s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticle"
 
-    s.ios.deployment_target = "15.0"
+    s.ios.deployment_target = "16.0"
     s.ios.source_files      = 'mParticle-UrbanAirship/*.{h,m,mm,swift}'
     s.ios.resource_bundles = { 'mParticle-UrbanAirship-Privacy' => ['mParticle-UrbanAirship/PrivacyInfo.xcprivacy'] }
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
-    s.ios.dependency 'Airship/ObjectiveC', '~> 19.1'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.41'
+    s.ios.dependency 'Airship/ObjectiveC', '~> 20.0.3'
 end
 


### PR DESCRIPTION
 ## Summary
 - Airship have released their major SDK [release](https://docs.airship.com/developer/sdk-integration/apple/ios-changelog/#20.0.0) with v20 and this PR upgrades the Airship SDK to it. This was requested by a customers alongside the same for Android. I have checked Airship's migration docs and doesn't seem functionality wise there should be any changes, please review [here](https://github.com/urbanairship/ios-library/blob/main/Documentation/Migration/migration-guide-19-20.md) and let me know if something is missing

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - N/A

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-863
