### PR TITLE
feat: Update to Airship SDK 20.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
                .upToNextMajor(from: "8.41.1")),
       .package(name: "Airship",
                url: "https://github.com/urbanairship/ios-library",
-               .upToNextMajor(from: "20.0.3")),
+               .upToNextMajor(from: "20.4.0")),
     ],
     targets: [
         .target(

--- a/mParticle-UrbanAirship.podspec
+++ b/mParticle-UrbanAirship.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
     s.ios.source_files      = 'mParticle-UrbanAirship/*.{h,m,mm,swift}'
     s.ios.resource_bundles = { 'mParticle-UrbanAirship-Privacy' => ['mParticle-UrbanAirship/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.41'
-    s.ios.dependency 'Airship/ObjectiveC', '~> 20.0.3'
+    s.ios.dependency 'Airship/ObjectiveC', '~> 20.4.0'
 end
 


### PR DESCRIPTION
 ## Summary
Updates the Airship SDK to 20.4.0. We follow (at least try) semvar so this should be a drop in replacement. This a request by a shared user who needs an update to fix a Message Center issue. 

https://github.com/urbanairship/ios-library/issues/450

Pods is still deploying so I may need to retry a job if it fails.  - https://github.com/urbanairship/ios-library/actions/runs/22411062087/job/64886552124

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 
 This has not been tested locally. I do not have an mparticle account setup. 

