### PR TITLE
feat: Update to Airship SDK 20.6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
                .upToNextMajor(from: "8.41.1")),
       .package(name: "Airship",
                url: "https://github.com/urbanairship/ios-library",
-               .upToNextMajor(from: "20.4.0")),
+               .upToNextMajor(from: "20.6.0")),
     ],
     targets: [
         .target(

--- a/mParticle-UrbanAirship.podspec
+++ b/mParticle-UrbanAirship.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
     s.ios.source_files      = 'mParticle-UrbanAirship/*.{h,m,mm,swift}'
     s.ios.resource_bundles = { 'mParticle-UrbanAirship-Privacy' => ['mParticle-UrbanAirship/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.41'
-    s.ios.dependency 'Airship/ObjectiveC', '~> 20.4.0'
+    s.ios.dependency 'Airship/ObjectiveC', '~> 20.6.0'
 end
 


### PR DESCRIPTION
 ## Summary
Updates Airship SDK to 20.6.0:

20.6.0:
- Added `UAMessageCenterNativeBridge` and `UAMessageCenterNativeBridgeDelegate` to support .NET MAUI bindings for Message Center web view deep link handling.
- Added subscript and superscript text support in Scenes.
- Fixed Message Center mark-as-read not updating the list UI.
- Improved Message Center content type handling.
- Improved Message Center behavior when a message is unavailable or deleted.

20.5.0:
- Improved pager navigation reliability by fixing a race condition that could cause desync when swiping rapidly during scroll.
- Improved NPS score selector tap targets to remain consistent when toggling between selected and unselected states.
- Improved video playback lifecycle handling to prevent potential memory leaks on dismiss.
- Improved In-App Automation schedule parsing to retry failed schedules when remote data is updated.
- Removed remaining Objective-C from AirshipBasement.
- Replaced Objective-C based swizzling with a more reliable Swift implementation.
- Fixed video aspect ratio to avoid cropping content when using center-inside display mode.


 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.

No, I do not have mParticle account setup. The Airship SDK follows strict semvar versioning, so it should be fine to update minor/patches.

